### PR TITLE
Fix accessibilty in query

### DIFF
--- a/Sources/SAMKeychainQuery.m
+++ b/Sources/SAMKeychainQuery.m
@@ -111,7 +111,7 @@
 	[query setObject:@YES forKey:(__bridge id)kSecReturnAttributes];
 	[query setObject:(__bridge id)kSecMatchLimitAll forKey:(__bridge id)kSecMatchLimit];
 #if __IPHONE_4_0 && TARGET_OS_IPHONE
-	CFTypeRef accessibilityType = self.accessibility;
+	CFTypeRef accessibilityType = (__bridge CFTypeRef)self.accessibility;
 	if (accessibilityType) {
 		[query setObject:(__bridge id)accessibilityType forKey:(__bridge id)kSecAttrAccessible];
 	}

--- a/Sources/SAMKeychainQuery.m
+++ b/Sources/SAMKeychainQuery.m
@@ -111,7 +111,7 @@
 	[query setObject:@YES forKey:(__bridge id)kSecReturnAttributes];
 	[query setObject:(__bridge id)kSecMatchLimitAll forKey:(__bridge id)kSecMatchLimit];
 #if __IPHONE_4_0 && TARGET_OS_IPHONE
-	CFTypeRef accessibilityType = [SAMKeychain accessibilityType];
+	CFTypeRef accessibilityType = self.accessibility ? (__bridge CFTypeRef)self.accessibility : [SAMKeychain accessibilityType];
 	if (accessibilityType) {
 		[query setObject:(__bridge id)accessibilityType forKey:(__bridge id)kSecAttrAccessible];
 	}

--- a/Sources/SAMKeychainQuery.m
+++ b/Sources/SAMKeychainQuery.m
@@ -111,7 +111,7 @@
 	[query setObject:@YES forKey:(__bridge id)kSecReturnAttributes];
 	[query setObject:(__bridge id)kSecMatchLimitAll forKey:(__bridge id)kSecMatchLimit];
 #if __IPHONE_4_0 && TARGET_OS_IPHONE
-	CFTypeRef accessibilityType = self.accessibility ? (__bridge CFTypeRef)self.accessibility : [SAMKeychain accessibilityType];
+	CFTypeRef accessibilityType = self.accessibility;
 	if (accessibilityType) {
 		[query setObject:(__bridge id)accessibilityType forKey:(__bridge id)kSecAttrAccessible];
 	}


### PR DESCRIPTION
For `fetchAll` query we explicitly take property value. If we rely on global value, once set it is not possible to perform query without setting accessibilityType and therefore not possible to get all items.

See https://github.com/soffes/SAMKeychain/issues/188